### PR TITLE
Use docker multi stage build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
   - docker
 
 install:
+  - docker -v
   - docker build -t adyen-card-tester .
   - docker run -d -p 127.0.0.1:80:5000 -e ADYEN_KEY="adyen public key" --name adyen-card-tester adyen-card-tester
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node
+# ---- Base ----
+FROM node AS base
 
 LABEL maintainer "tom@thomaslorentsen.co.uk"
 
@@ -7,6 +8,9 @@ WORKDIR /home/node/
 COPY package.json package.json
 
 RUN npm install
+
+# ---- App ----
+FROM base AS app
 
 COPY src/ .
 


### PR DESCRIPTION
> Starting from Docker 17.05+, you can create a single Dockerfile that can build multiple helper images with compilers, tools, and tests and use files from above images to produce the final Docker image